### PR TITLE
Insert organisation and relationships when creating a new user

### DIFF
--- a/matchmaker.cabal
+++ b/matchmaker.cabal
@@ -194,6 +194,7 @@ test-suite matchmaker-test
     DB.UserSpec
     DB.SpecHelpers
     DB.OrganisationSpec
+    Web.AccountCreationSpec
   mixins: base hiding (Prelude)
         , relude ( Relude as Prelude
                  , Relude.Unsafe)

--- a/migrations/20210423114034_users.sql
+++ b/migrations/20210423114034_users.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS users (
 	user_id uuid PRIMARY KEY,
 	username TEXT NOT NULL,
-  email TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
 	display_name TEXT NOT NULL,
 	password TEXT NOT NULL,
 	created_at TIMESTAMPTZ NOT NULL,

--- a/src/Handler/Account/Create.hs
+++ b/src/Handler/Account/Create.hs
@@ -1,6 +1,9 @@
 module Handler.Account.Create where
 
+import DB.Organisation
 import DB.User
+import Data.Time
+import Data.UUID.V4 (nextRandom)
 import ImportYesod
 import Model.UserModel
 import Web.Form
@@ -15,6 +18,28 @@ postAccountCreateR = do
       putAssign "form_error" "true"
       handleFormErrors errors
       redirect SignupR
-    Result user -> do
-      runDB $ insertUser user
+    Result user@User{..} -> do
+      orgId <- liftIO $ OrganisationId <$> nextRandom
+      userOrgId <- liftIO $ UserOrganisationId <$> nextRandom
+      timestamp <- liftIO getCurrentTime
+      let org = newOrganisationFor orgId timestamp user
+      runDB
+        $ insertUser user
+        *> insertOrganisation org
+        *> attachUser userId orgId userOrgId
       redirect HomeR
+  where
+    newOrganisationFor :: OrganisationId -> UTCTime -> User -> Organisation
+    newOrganisationFor organisationId createdAt user =
+      Organisation
+        { organisationId
+        , organisationName = newOrgNameFrom user
+        , createdAt
+        , updatedAt = createdAt
+        }
+
+    newOrgNameFrom :: User -> Text
+    newOrgNameFrom User{..} = userOrgNamePrefix <> username
+
+    userOrgNamePrefix :: Text
+    userOrgNamePrefix = "default_org_for"

--- a/src/Handler/Account/Create.hs
+++ b/src/Handler/Account/Create.hs
@@ -1,9 +1,11 @@
 module Handler.Account.Create where
 
+import Control.Monad.Except (throwError)
 import DB.Organisation
 import DB.User
 import Data.Time
 import Data.UUID.V4 (nextRandom)
+import Database.PostgreSQL.Transact (DBT)
 import ImportYesod
 import Model.UserModel
 import Web.Form
@@ -12,22 +14,30 @@ import Web.Sessions
 postAccountCreateR :: Handler ()
 postAccountCreateR = do
   postParams <- getPostParams
-  newUser <- liftIO $ validateNewUser postParams
-  case newUser of
-    FieldErrors errors -> do
+  result <- runDB $ runExceptT $ postAccountCreate postParams
+  case result of
+    Left errors -> do
       putAssign "form_error" "true"
       handleFormErrors errors
       redirect SignupR
+    Right _ ->
+      redirect HomeR
+
+postAccountCreate
+  :: [(Text, Text)]
+  -> ExceptT (NonEmpty NewUserValidationError) (DBT IO) ()
+postAccountCreate postParams = do
+  newUser <- liftIO $ validateNewUser postParams
+  case newUser of
+    FieldErrors errors -> throwError errors
     Result user@User{..} -> do
       orgId <- liftIO $ OrganisationId <$> nextRandom
       userOrgId <- liftIO $ UserOrganisationId <$> nextRandom
       timestamp <- liftIO getCurrentTime
       let org = newOrganisationFor orgId timestamp user
-      runDB
-        $ insertUser user
+      lift $ insertUser user
         *> insertOrganisation org
         *> attachUser userId orgId userOrgId
-      redirect HomeR
   where
     newOrganisationFor :: OrganisationId -> UTCTime -> User -> Organisation
     newOrganisationFor organisationId createdAt user =
@@ -42,4 +52,4 @@ postAccountCreateR = do
     newOrgNameFrom User{..} = userOrgNamePrefix <> username
 
     userOrgNamePrefix :: Text
-    userOrgNamePrefix = "default_org_for"
+    userOrgNamePrefix = "default_org_for_"

--- a/src/Model/UserModel.hs
+++ b/src/Model/UserModel.hs
@@ -16,6 +16,7 @@ data NewUserValidationError
   | TooShortPassword
   | InvalidEmailAddress
   | MissingField Text
+  deriving Show
 
 instance ErrorToAssign NewUserValidationError where
   putErrorAssign err =

--- a/test/DB/OrganisationSpec.hs
+++ b/test/DB/OrganisationSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
@@ -8,13 +9,13 @@ import Data.UUID.V4
 import Relude.Unsafe (read)
 import Test.Hspec (Spec)
 import Test.Hspec.DB (describeDB, itDB)
-import Test.Hspec.Expectations.Lifted (shouldReturn)
+import Test.Hspec.Expectations.Lifted (expectationFailure, shouldReturn)
 
 import DB.Organisation (Organisation (..), OrganisationId (..),
                         UserOrganisationId (..), attachUser, getAdmins,
-                        getAllUserOrganisations, getUserOrganisation,
-                        getUserOrganisationById, getUsers, insertOrganisation,
-                        makeAdmin)
+                        getAllUserOrganisations, getOrganisationByName,
+                        getUserOrganisation, getUserOrganisationById, getUsers,
+                        insertOrganisation, makeAdmin)
 import DB.SpecHelpers (migrate)
 import DB.User
 

--- a/test/DB/OrganisationSpec.hs
+++ b/test/DB/OrganisationSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase      #-}
+
 {-# LANGUAGE OverloadedLists #-}
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 
 import qualified DB.OrganisationSpec as OrganisationSpec
 import qualified DB.UserSpec as UserSpec
+import qualified Web.AccountCreationSpec as AccountCreationSpec
 -- import qualified RepositorySpec as RepositorySpec
 
 main :: IO ()
@@ -13,3 +14,4 @@ spec :: Spec
 spec = do
     UserSpec.spec
     OrganisationSpec.spec
+    AccountCreationSpec.spec

--- a/test/Web/AccountCreationSpec.hs
+++ b/test/Web/AccountCreationSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Web.AccountCreationSpec where
+
+import Test.Hspec (Spec)
+import Test.Hspec.DB (describeDB, itDB)
+import Test.Hspec.Expectations.Lifted (expectationFailure)
+
+import DB.Organisation (getOrganisationByName)
+import DB.SpecHelpers (migrate)
+import Handler.Account.Create (postAccountCreate)
+
+postData1 :: [(Text, Text)]
+postData1 =
+  [ ("username"   , "wildcat")
+  , ("email"      , "force_captain@horde.io")
+  , ("displayname", "Catra")
+  , ("password"   , "adorauwu")
+  ]
+
+spec :: Spec
+spec = describeDB migrate "org" $ do
+  itDB "Users have a default organisation" $ do
+    let orgName = "default_org_for_wildcat"
+    runExceptT (postAccountCreate postData1) >>= \case
+      Left errors -> expectationFailure $ "Validation error(s): " <> show errors
+      Right _     -> pure ()
+    whenNothingM_ (getOrganisationByName orgName)
+      $ expectationFailure "no default org created or name formatting changed"


### PR DESCRIPTION
Closes #3 

TODO:
- [x] validate that `runDB` runs in a transaction
- [x] see what happens if the org name already exists (expectation: error due to conflict, rollback; is this acceptable?)
- [x] add tests