### PR TITLE
Consolidate development scripts into `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ghcid: dev
 dev: ## Start ghcid
-	@ghcid --command 'cabal new-repl lib:matchmaker' --allow-eval --warnings -o ghcid.text
+	@ghcid --target lib:matchmaker --allow-eval --warnings -o ghcid.text
 
 start: ## Start the server
 	@cabal run exe:matchmaker

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 start: ## Start the server
-	@cabal run matchmaker
+	@cabal run exe:matchmaker
 
 deps: ## Install the dependencies of the backend
 	@cabal install postgresql-simple-migration

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test: ## Run the test suite
 lint: ## Run the code linter (HLint)
 	@find app test src -name "*.hs" | parallel -j $(PROCS) -- hlint --refactor-options="-i" --refactor {}
 
+format: style
 style: ## Run the code styler (stylish-haskell)
 	@stylish-haskell -i -r src app test
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ghcid: dev
+dev: ## Start ghcid
+	@ghcid --command 'cabal new-repl lib:matchmaker' --allow-eval --warnings -o ghcid.text
+
 start: ## Start the server
 	@cabal run exe:matchmaker
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ghcid: dev
 dev: ## Start ghcid
-	@ghcid --target lib:matchmaker --allow-eval --warnings -o ghcid.text
+	@ghcid --target lib:matchmaker --allow-eval --warnings
 
 start: ## Start the server
 	@cabal run exe:matchmaker

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ and provide a smoother experience for people wishing to invest themselves in the
 There is a `shell.nix` file provided for convenience. However it is far from perfect.
 It will not manage a local installation of PostgreSQL for you.
 You should be able to work in a pure shell. If not, file a bug!
-The nix shell should source all environment variables when you enter it. Additionally it provides 3 convenience scripts:
+The nix shell should source all environment variables when you enter it.
 
-1.  `dev` - This will run ghcid with a couple flags enabled
-2.  `run` - This will run the matchmaker application
-3.  `format` - This will run `stylish-haskell` on all .hs files in the current directory and below
+The `Makefile` contains all the development-related scripts you'll need. Please
+refer to the output of `make help` for more information.
 
 ## Run the backend
 

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,6 @@ let pkgs = import (builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/9fc2cddf24ad1819f17174cbae47789294ea6dc4.tar.gz";
       sha256 = "058l6ry119mkg7pwmm7z4rl1721w0zigklskq48xb5lmgig4l332";
     }) { };
-    formatScript = pkgs.writeShellScriptBin "format" "stylish-haskell -ir ./**/*.hs";
 in with pkgs;
   mkShell {
     shellHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,6 @@ let pkgs = import (builtins.fetchTarball {
     }) { };
     ghcidScript = pkgs.writeShellScriptBin "dev" "ghcid --command 'cabal new-repl lib:matchmaker' --allow-eval --warnings -o ghcid.text";
     formatScript = pkgs.writeShellScriptBin "format" "stylish-haskell -ir ./**/*.hs";
-    runScript = pkgs.writeShellScriptBin "run" "cabal run exe:matchmaker";
 in with pkgs;
   mkShell {
     shellHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,6 @@ let pkgs = import (builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/9fc2cddf24ad1819f17174cbae47789294ea6dc4.tar.gz";
       sha256 = "058l6ry119mkg7pwmm7z4rl1721w0zigklskq48xb5lmgig4l332";
     }) { };
-    ghcidScript = pkgs.writeShellScriptBin "dev" "ghcid --command 'cabal new-repl lib:matchmaker' --allow-eval --warnings -o ghcid.text";
     formatScript = pkgs.writeShellScriptBin "format" "stylish-haskell -ir ./**/*.hs";
 in with pkgs;
   mkShell {

--- a/shell.nix
+++ b/shell.nix
@@ -31,10 +31,5 @@ in with pkgs;
       # Extra
       direnv
       parallel
-
-      # Scripts
-      ghcidScript
-      formatScript
-      runScript
     ];
   }


### PR DESCRIPTION
I noticed some duplication between commands defined in the `Makefile` and scripts added to the Nix shell's `PATH`. I think the `Makefile` is a better place for this stuff, so I consolidated everything there.